### PR TITLE
v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 blah blah insert blurb here about high-level shit
 
 TODO
-- make a version of the purple shirt woman emoji set that looks like janet
 - fix emojitools so it can be used as a module here
 - attribute announcements
     - need to add a db or something maybe?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reactjibot",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactjibot",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "dist/index.js",
   "engines": {

--- a/src/BotClient.js
+++ b/src/BotClient.js
@@ -40,9 +40,13 @@ const methods = (app, platform) => ({
         app.command(commandName, async args => {
             const handler = createHandler(args.command)
             await args.ack()
-            await handler.handle(
-                this.sendMessage.bind(this, args.client)
-            )
+            try {
+                await handler.handle(
+                    this.sendMessage.bind(this, args.client)
+                )
+            } catch (err) {
+                console.error(err)
+            }
         })
 
         return this

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
 module.exports = {
     DEFAULTS: {
         CHANNEL: process.env.DEFAULT_CHANNEL || 'reactjibot',
-        ICON: process.env.DEFAULT_ICON || ':woman-tipping-hand::skin-tone-2:'
+        ICON: process.env.DEFAULT_ICON || ':robot:'
     },
     BOT_NAME: process.env.BOT_NAME || 'ReactjiBot'
 }


### PR DESCRIPTION
cool cool i have a deploy flow set up on heroku and also this works and is configurable and it dumps emoji announcements into a given channel! i call that good enough to start doing something resembling semver

specific things i guess:
- doesn't barf on errors so my heroku instance stays up
- announces when emojis/aliases are added or removed
- has env var configurable bot name, icon and announcement channel